### PR TITLE
Include WASM build in pnpm build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is a comprehensive macro system implementation for [swc macro propo
 # Install dependencies
 pnpm install
 
-# Build all packages (Rust + JavaScript)
+# Build all packages (Rust + WASM + JavaScript)
 pnpm build
 
 # Run all tests
@@ -33,7 +33,10 @@ pnpm test:ci
 rustup target add wasm32-unknown-unknown
 
 # Build the WASM binding
-(cd crates/swc_macro_wasm && wasm-pack build --release)
+pnpm build:wasm
+
+# Or build everything
+pnpm build
 
 # Your wasm file will be in `crates/swc_macro_wasm/pkg/`
 ```
@@ -97,7 +100,7 @@ This demonstrates:
 Test tree-shaking with real webpack bundles:
 
 ```bash
-# Build WASM module first
+# Build WASM module first (included in pnpm build)
 pnpm build
 
 # Run optimization on test cases

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,7 +53,7 @@ pnpm test:ui
 
 | Command | Description |
 |---------|-------------|
-| `pnpm build` | Build all packages (Rust + JS) |
+| `pnpm build` | Build all packages (Rust + WASM + JS) |
 | `pnpm lint` | Lint all code (Rust + JS) |
 | `pnpm clean` | Clean all build artifacts |
 

--- a/examples/jsx-server-demo/package.json
+++ b/examples/jsx-server-demo/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "jsx-demo": "node --experimental-wasm-modules jsx-test-server.mjs",
-    "build-wasm": "cd ../../crates/swc_macro_wasm && wasm-pack build --release"
+    "build-wasm": "pnpm -C ../../ build:wasm"
   },
   "dependencies": {
     "@swc/core": "^1.3.107",

--- a/examples/module-federation-example/scripts/build-optimize-test.js
+++ b/examples/module-federation-example/scripts/build-optimize-test.js
@@ -95,7 +95,7 @@ async function runPipeline() {
     } catch (error) {
       console.error('❌ Failed to load SWC macro optimizer:', error.message);
       console.log('Please ensure:');
-      console.log('1. WASM package is built: cd crates/swc_macro_wasm && wasm-pack build --release');
+      console.log('1. WASM package is built: pnpm build:wasm (or pnpm build)');
       console.log('2. Script is run with: node --experimental-wasm-modules');
       throw error;
     }

--- a/examples/module-federation-example/scripts/optimize-shared-chunks.js
+++ b/examples/module-federation-example/scripts/optimize-shared-chunks.js
@@ -17,7 +17,7 @@ async function loadOptimizer() {
   } catch (error) {
     console.error('Failed to load SWC macro optimizer:', error.message);
     console.log('Please ensure:');
-    console.log('1. WASM package is built: cd crates/swc_macro_wasm && wasm-pack build --release');
+    console.log('1. WASM package is built: pnpm build:wasm (or pnpm build)');
     console.log('2. Script is run with: node --experimental-wasm-modules');
     process.exit(1);
   }

--- a/examples/module-federation-react-example/scripts/optimize-shared-chunks.js
+++ b/examples/module-federation-react-example/scripts/optimize-shared-chunks.js
@@ -17,7 +17,7 @@ async function loadOptimizer() {
   } catch (error) {
     console.error('Failed to load SWC macro optimizer:', error.message);
     console.log('Please ensure:');
-    console.log('1. WASM package is built: cd crates/swc_macro_wasm && wasm-pack build --release');
+    console.log('1. WASM package is built: pnpm build:wasm (or pnpm build)');
     console.log('2. Script is run with: node --experimental-wasm-modules');
     process.exit(1);
   }

--- a/examples/module-federation-web-example/scripts/build-optimize-test.js
+++ b/examples/module-federation-web-example/scripts/build-optimize-test.js
@@ -95,7 +95,7 @@ async function runPipeline() {
     } catch (error) {
       console.error('❌ Failed to load SWC macro optimizer:', error.message);
       console.log('Please ensure:');
-      console.log('1. WASM package is built: cd crates/swc_macro_wasm && wasm-pack build --release');
+      console.log('1. WASM package is built: pnpm build:wasm (or pnpm build)');
       console.log('2. Script is run with: node --experimental-wasm-modules');
       throw error;
     }

--- a/examples/module-federation-web-example/scripts/optimize-shared-chunks.js
+++ b/examples/module-federation-web-example/scripts/optimize-shared-chunks.js
@@ -17,7 +17,7 @@ async function loadOptimizer() {
   } catch (error) {
     console.error('Failed to load SWC macro optimizer:', error.message);
     console.log('Please ensure:');
-    console.log('1. WASM package is built: cd crates/swc_macro_wasm && wasm-pack build --release');
+    console.log('1. WASM package is built: pnpm build:wasm (or pnpm build)');
     console.log('2. Script is run with: node --experimental-wasm-modules');
     process.exit(1);
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "example_wasm_usage.js",
   "scripts": {
     "start": "node --experimental-wasm-modules example_wasm_usage.js",
-    "build-wasm": "cd crates/swc_macro_wasm && wasm-pack build --release",
+    "build:wasm": "cd crates/swc_macro_wasm && wasm-pack build --release",
+    "build-wasm": "pnpm build:wasm",
     "test": "run-s test:rust test:js",
     "test:rust": "cargo test --workspace",
     "test:js": "pnpm -r test",
@@ -27,7 +28,7 @@
     "test:coverage:root": "vitest run --coverage",
     "test:coverage:workspaces": "pnpm -r test:coverage",
     "test:ci": "run-s build test:all",
-    "build": "run-s build:rust build:js",
+    "build": "run-s build:rust build:wasm build:js",
     "build:rust": "cargo build --release --workspace",
     "build:js": "pnpm -r --filter=!examples/module-federation-example --filter=!examples/module-federation-web-example build",
     "optimize:examples": "pnpm -C examples/module-federation-example optimize && pnpm -C examples/module-federation-web-example optimize",


### PR DESCRIPTION
## Summary
- build WASM bindings via new `build:wasm` script and run it from `pnpm build`
- document combined Rust+WASM+JS build and update examples to point to `pnpm build:wasm`

## Testing
- `pnpm build`
- `pnpm test` *(fails: Failed to load SWC macro optimizer in module-federation-web-example)*

------
https://chatgpt.com/codex/tasks/task_e_689c1d7feb7c8325b02de3491b536129