### PR TITLE
Guard tree shaker against panics and add config parsing test

### DIFF
--- a/crates/swc_macro_wasm/src/dce.rs
+++ b/crates/swc_macro_wasm/src/dce.rs
@@ -113,6 +113,9 @@ struct Data {
     entries: FxHashSet<u32>,
 
     graph_ix: IndexSet<Id, FxBuildHasher>,
+
+    /// Track identifiers declared with `var` so we can preserve their assignments.
+    var_ids: FxHashSet<Id>,
 }
 
 impl Data {
@@ -160,6 +163,14 @@ impl Data {
             self.graph_ix.insert_full(id.clone());
             ix
         }) as _
+    }
+
+    fn mark_var(&mut self, id: Id) {
+        self.var_ids.insert(id);
+    }
+
+    fn is_var(&self, id: &Id) -> bool {
+        self.var_ids.contains(id)
     }
 
     /// Add an edge to dependency graph
@@ -308,6 +319,7 @@ struct Analyzer<'a> {
     #[allow(dead_code)]
     config: &'a Config,
     in_var_decl: bool,
+    var_decl_kind: Option<VarDeclKind>,
     scope: Scope<'a>,
     data: &'a mut Data,
     cur_class_id: Option<Id>,
@@ -632,6 +644,13 @@ impl Visit for Analyzer<'_> {
         }
     }
 
+    fn visit_var_decl(&mut self, n: &VarDecl) {
+        let old = self.var_decl_kind;
+        self.var_decl_kind = Some(n.kind);
+        n.visit_children_with(self);
+        self.var_decl_kind = old;
+    }
+
     fn visit_var_declarator(&mut self, n: &VarDeclarator) {
         let old = self.in_var_decl;
 
@@ -642,6 +661,12 @@ impl Visit for Analyzer<'_> {
         n.init.visit_with(self);
 
         self.in_var_decl = old;
+
+        if let Pat::Ident(i) = &n.name {
+            if self.var_decl_kind == Some(VarDeclKind::Var) {
+                self.data.mark_var(i.to_id());
+            }
+        }
     }
 }
 
@@ -773,8 +798,8 @@ impl VisitMut for TreeShaker {
         n.visit_mut_children_with(self);
 
         if let Some(id) = n.left.as_ident() {
-            // TODO: `var`
-            if self.can_drop_assignment_to(id.to_id(), false)
+            let is_var = self.data.is_var(&id.to_id());
+            if self.can_drop_assignment_to(id.to_id(), is_var)
                 && !may_have_side_effects(&self.comments, &n.right, self.expr_ctx)
             {
                 self.changed = true;
@@ -990,6 +1015,7 @@ impl VisitMut for TreeShaker {
                 let mut analyzer = Analyzer {
                     config: &self.config,
                     in_var_decl: false,
+                    var_decl_kind: None,
                     scope: Default::default(),
                     data: &mut data,
                     cur_class_id: Default::default(),
@@ -1053,6 +1079,7 @@ impl VisitMut for TreeShaker {
                 let mut analyzer = Analyzer {
                     config: &self.config,
                     in_var_decl: false,
+                    var_decl_kind: None,
                     scope: Default::default(),
                     data: &mut data,
                     cur_class_id: Default::default(),

--- a/crates/swc_macro_wasm/src/lib.rs
+++ b/crates/swc_macro_wasm/src/lib.rs
@@ -13,7 +13,7 @@ pub fn optimize(source: String, config: &str) -> String {
     let config: serde_json::Value = match serde_json::from_str(config) {
         Ok(cfg) => cfg,
         Err(e) => {
-            eprintln!("Warning: Invalid config JSON: {}. Using empty config.", e);
+            tracing::warn!("Invalid config JSON: {}. Using original source.", e);
             // Return original source if config is invalid
             return source;
         }
@@ -22,7 +22,7 @@ pub fn optimize(source: String, config: &str) -> String {
     match optimize::optimize(source.clone(), config) {
         Ok(result) => result,
         Err(err) => {
-            eprintln!("Optimization error: {}", err);
+            tracing::error!("Optimization error: {}", err);
             source
         }
     }
@@ -157,5 +157,14 @@ mod tests {
         
         println!("Tree shaking with macro conditions test passed!");
         println!("All modules successfully tree shaken due to no entry points");
+    }
+
+    #[test]
+    fn test_invalid_config_does_not_panic() {
+        let source = "console.log('hello');".to_string();
+        // Pass deliberately invalid JSON
+        let result = super::optimize(source.clone(), "{not valid json}");
+        // When config parsing fails we should get the original source back
+        assert_eq!(result, source);
     }
 }

--- a/crates/swc_macro_wasm/src/optimize.rs
+++ b/crates/swc_macro_wasm/src/optimize.rs
@@ -1,4 +1,5 @@
 use rustc_hash::FxHashSet;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::time::{Duration, Instant};
 use swc_common::comments::SingleThreadedComments;
 use swc_common::pass::Repeated;
@@ -77,11 +78,15 @@ pub fn optimize(source: String, config: serde_json::Value) -> OptimizationResult
 
             perform_dce(&mut program, comments.clone(), unresolved_mark);
 
-            // Tree shake webpack modules - DISABLED: causes panic in WASM builds
-            // The TreeShaker/webpack_analyzer_v2 has WASM compatibility issues
-            // TODO: Fix WASM compatibility in webpack_analyzer_v2
-            // let mut tree_shaker = TreeShaker::new(config.clone());
-            // tree_shaker.optimize(&mut program, cm.clone(), &comments);
+            // Run tree shaker but guard against panics from the analyzer in WASM builds
+            if has_macro_processing_config(&config) {
+                let mut tree_shaker = TreeShaker::new(config.clone());
+                if let Err(err) = catch_unwind(AssertUnwindSafe(|| {
+                    tree_shaker.optimize(&mut program, cm.clone(), &comments);
+                })) {
+                    tracing::warn!("Tree shaking skipped due to panic: {:?}", err);
+                }
+            }
 
             program.mutate(fixer(Some(&comments)));
 


### PR DESCRIPTION
## Summary
- protect tree shaker execution in `optimize` with `catch_unwind`
- add unit test verifying optimizer handles invalid config JSON without panicking
- track `var` declarations in DCE so assignments aren't dropped for hoisted variables
- log invalid config and tree shaker failures via `tracing` instead of `stderr`

## Testing
- `cargo test -p swc_macro_wasm`
- `pnpm install` *(fails: workspace package swc_macro_wasm missing)*
- `pnpm run build` *(fails: run-s: not found)*
- `pnpm run test:workspaces` *(fails: missing node_modules/rspack)*

------
https://chatgpt.com/codex/tasks/task_e_689c376f18748325a9d28c076aa3f096